### PR TITLE
Added support to properly convert and generate`Resize`, `Conv` (which in turn are represented as `DepthwiseConv` and `PointwiseConv` in hls4ml representation) 

### DIFF
--- a/hls4ml/backends/vivado/passes/conv_same_pad.py
+++ b/hls4ml/backends/vivado/passes/conv_same_pad.py
@@ -8,6 +8,8 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
     def match(self, node):
         is_match = (
             isinstance(node, (Conv1D, SeparableConv1D, DepthwiseConv1D))
+            and ((node.get_attr('pad_left') == node.get_attr('pad_right')) 
+                 or (node.get_attr('pad_left') > 0 and node.get_attr('pad_right') == 0)) # checking if it is padding same or causal
             and ((node.get_attr('padding') == 'same') or (node.get_attr('padding') == 'causal'))
             and node.get_attr('filt_width') != 1
         )
@@ -56,7 +58,7 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
     def match(self, node):
         is_match = (
             isinstance(node, (Conv2D, SeparableConv2D, DepthwiseConv2D))
-            # and node.get_attr('padding') == 'same'
+            and node.get_attr('pad_top') == node.get_attr('pad_bottom') and node.get_attr('pad_left') == node.get_attr('pad_right') # checking if it is padding same
             and node.get_attr('filt_height') != 1
             and node.get_attr('filt_width') != 1
         )

--- a/hls4ml/backends/vivado/passes/conv_same_pad.py
+++ b/hls4ml/backends/vivado/passes/conv_same_pad.py
@@ -1,4 +1,4 @@
-from hls4ml.model.layers import Conv1D, Conv2D, SeparableConv1D, SeparableConv2D
+from hls4ml.model.layers import Conv1D, Conv2D, DepthwiseConv2D, DepthwiseConv1D, SeparableConv1D, SeparableConv2D
 from hls4ml.model.optimizer import OptimizerPass
 
 
@@ -7,7 +7,7 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
 
     def match(self, node):
         is_match = (
-            isinstance(node, (Conv1D, SeparableConv1D))
+            isinstance(node, (Conv1D, SeparableConv1D, DepthwiseConv1D))
             and ((node.get_attr('padding') == 'same') or (node.get_attr('padding') == 'causal'))
             and node.get_attr('filt_width') != 1
         )
@@ -55,8 +55,8 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
 
     def match(self, node):
         is_match = (
-            isinstance(node, (Conv2D, SeparableConv2D))
-            and node.get_attr('padding') == 'same'
+            isinstance(node, (Conv2D, SeparableConv2D, DepthwiseConv2D))
+            # and node.get_attr('padding') == 'same'
             and node.get_attr('filt_height') != 1
             and node.get_attr('filt_width') != 1
         )

--- a/hls4ml/backends/vivado/passes/conv_same_pad.py
+++ b/hls4ml/backends/vivado/passes/conv_same_pad.py
@@ -1,4 +1,4 @@
-from hls4ml.model.layers import Conv1D, Conv2D, DepthwiseConv2D, DepthwiseConv1D, SeparableConv1D, SeparableConv2D
+from hls4ml.model.layers import Conv1D, Conv2D, DepthwiseConv1D, DepthwiseConv2D, SeparableConv1D, SeparableConv2D
 from hls4ml.model.optimizer import OptimizerPass
 
 

--- a/hls4ml/backends/vivado/passes/pointwise.py
+++ b/hls4ml/backends/vivado/passes/pointwise.py
@@ -77,7 +77,9 @@ class OptimizePointwiseConv(OptimizerPass):
 
     def transform(self, model, node):
         dim = node.__class__.__name__[-2:]  # '1D' or '2D'
-        pw_node = model.make_node('PointwiseConv' + dim, node.name, copy(node.attributes), node.inputs.copy(), [x for x in node.outputs])
+        pw_node = model.make_node(
+            'PointwiseConv' + dim, node.name, copy(node.attributes), node.inputs.copy(), [x for x in node.outputs]
+        )
         if len(node.weights['weight'].data.shape) == 2:  # This can happen if we assign weights of Dense layer to 1x1 Conv2D
             expand_axis = tuple(range(int(dim[0])))
             pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=expand_axis)

--- a/hls4ml/backends/vivado/passes/pointwise.py
+++ b/hls4ml/backends/vivado/passes/pointwise.py
@@ -77,7 +77,7 @@ class OptimizePointwiseConv(OptimizerPass):
 
     def transform(self, model, node):
         dim = node.__class__.__name__[-2:]  # '1D' or '2D'
-        pw_node = model.make_node('PointwiseConv' + dim, node.name, copy(node.attributes), node.inputs.copy())
+        pw_node = model.make_node('PointwiseConv' + dim, node.name, copy(node.attributes), node.inputs.copy(), [x for x in node.outputs])
         if len(node.weights['weight'].data.shape) == 2:  # This can happen if we assign weights of Dense layer to 1x1 Conv2D
             expand_axis = tuple(range(int(dim[0])))
             pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=expand_axis)

--- a/hls4ml/converters/onnx/convolution.py
+++ b/hls4ml/converters/onnx/convolution.py
@@ -21,12 +21,11 @@ def parse_conv_layer(node, input_names, input_shapes, graph):
     if dilations is None:
         dilations = [1] * len(layer['kernel_shape'])
 
-    if get_onnx_attribute(node, 'group') != 1:
-        raise ValueError("Only 1 group supported corrently")
-
     layer['in_width'] = input_shapes[0][-2]
     layer['n_chan'] = input_shapes[0][-1]
     layer['n_filt'] = input_shapes[1][0]
+
+    layer['group'] = int(get_onnx_attribute(node, 'group'))
 
     layer['n_dim'] = len(input_shapes[0]) - 2  # 2 comes from channels and batch dimentions
     if layer['n_dim'] not in (1, 2):

--- a/hls4ml/converters/onnx/reshape.py
+++ b/hls4ml/converters/onnx/reshape.py
@@ -42,15 +42,15 @@ def parse_flatten_layer(node, input_names, input_shapes, graph):
 
 @onnx_handler('Resize')
 def parse_resize_layer(node, input_names, input_shapes, graph):
-    def get_scales(graph, name, scale_shapes):
-        for i in graph.initializer:
-            if i.name == name:
-                fmt = "<"
-                for _ in range(scale_shapes):
-                    fmt += "f"
-                return struct.unpack(fmt, i.raw_data)
+    # def get_scales(graph, name, scale_shapes):
+    #     for i in graph.initializer:
+    #         if i.name == name:
+    #             fmt = "<"
+    #             for _ in range(scale_shapes):
+    #                 fmt += "f"
+    #             return struct.unpack(fmt, i.raw_data)
 
-    scales = get_scales(graph, node.input[-1], input_shapes[-1][0])
+    # scales = get_scales(graph, node.input[-1], input_shapes[-1][0])
     layer = {}
     layer['name'] = node.name
     layer['class_name'] = 'Resize'
@@ -58,9 +58,12 @@ def parse_resize_layer(node, input_names, input_shapes, graph):
     layer['outputs'] = list(node.output)
     layer['in_height'] = input_shapes[0][2]
     layer['in_width'] = input_shapes[0][1]
-    layer['out_width'] = int(input_shapes[0][1] * scales[1])
-    layer['out_height'] = int(input_shapes[0][2] * scales[2])
-    layer['n_chan'] = int(input_shapes[0][3] * scales[3])
+    # layer['out_width'] = int(input_shapes[0][1] * scales[1])
+    # layer['out_height'] = int(input_shapes[0][2] * scales[2])
+    # layer['n_chan'] = int(input_shapes[0][3] * scales[3])
+    layer['out_width'] = input_shapes[0][1]
+    layer['out_height'] = input_shapes[0][2]
+    layer['n_chan'] = input_shapes[0][3]
     layer['algorithm'] = get_onnx_attribute(node, 'mode')
 
     return layer

--- a/hls4ml/converters/onnx/reshape.py
+++ b/hls4ml/converters/onnx/reshape.py
@@ -1,4 +1,5 @@
-from hls4ml.converters.onnx_to_hls import onnx_handler
+from hls4ml.converters.onnx_to_hls import get_onnx_attribute, onnx_handler
+import struct
 
 
 @onnx_handler('Transpose')
@@ -34,5 +35,30 @@ def parse_flatten_layer(node, input_names, input_shapes, graph):
     layer['inputs'] = input_names
     layer['outputs'] = list(node.output)
     layer['target_shape'] = [-1]  # does not contain batch dimension
+
+    return layer
+
+@onnx_handler('Resize')
+def parse_resize_layer(node, input_names, input_shapes, graph):
+    def get_scales(graph, name, scale_shapes):
+        for i in graph.initializer:
+            if i.name == name:
+                fmt = "<"
+                for _ in range(scale_shapes):
+                    fmt += "f"
+                return struct.unpack(fmt, i.raw_data)
+
+    scales = get_scales(graph, node.input[-1], input_shapes[-1][0])
+    layer = {}
+    layer['name'] = node.name
+    layer['class_name'] = 'Resize'
+    layer['inputs'] = input_names
+    layer['outputs'] = list(node.output)
+    layer['in_height'] = input_shapes[0][2]
+    layer['in_width'] = input_shapes[0][1]
+    layer['out_width'] = int(input_shapes[0][1] * scales[1])
+    layer['out_height'] = int(input_shapes[0][2] * scales[2])
+    layer['n_chan'] = int(input_shapes[0][3] * scales[3])
+    layer['algorithm'] = get_onnx_attribute(node, 'mode')
 
     return layer

--- a/hls4ml/converters/onnx/reshape.py
+++ b/hls4ml/converters/onnx/reshape.py
@@ -1,5 +1,6 @@
-from hls4ml.converters.onnx_to_hls import get_onnx_attribute, onnx_handler
 import struct
+
+from hls4ml.converters.onnx_to_hls import get_onnx_attribute, onnx_handler
 
 
 @onnx_handler('Transpose')
@@ -37,6 +38,7 @@ def parse_flatten_layer(node, input_names, input_shapes, graph):
     layer['target_shape'] = [-1]  # does not contain batch dimension
 
     return layer
+
 
 @onnx_handler('Resize')
 def parse_resize_layer(node, input_names, input_shapes, graph):

--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -63,6 +63,8 @@ def get_input_shape(graph, node):
     """
     rv = []
     for inp in node.input:
+        if inp == '':
+            continue
         try:
             value_info_idx = next((i for i, x in enumerate(graph.value_info) if x.name == inp))
             dim = list(d.dim_value for d in graph.value_info[value_info_idx].type.tensor_type.shape.dim)

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -1044,11 +1044,15 @@ class BiasAdd(Merge):  # TensorFlow's operator that gets merged into Dense/Conv
 class Resize(Layer):
     def initialize(self):
         inp = self.get_input_variable()
+        # get scales
+        scales = [1, 1, 1] if len(inp.shape) == 2 else [1, 1, 1, 1]
+        if len(self.inputs) > 1:
+            scales = self.get_input_node(self.inputs[-1]).get_attr('value')
         if len(inp.shape) == 2:  # 1D -> width + chan
-            shape = [self.get_attr('out_width'), self.get_attr('n_chan')]
+            shape = [int(self.get_attr('out_width') * scales[1]), int(self.get_attr('n_chan') * scales[2])]
             dims = [f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
         elif len(inp.shape) == 3:  # 2D -> height + width + chan
-            shape = [self.get_attr('out_height'), self.get_attr('out_width'), self.get_attr('n_chan')]
+            shape = [int(self.get_attr('out_height') * scales[1]), int(self.get_attr('out_width') * scales[2]), int(self.get_attr('n_chan') * scales[3])]
             dims = [f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
         self.add_output_variable(shape, dims, precision=inp.type.precision)
 

--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -34,6 +34,7 @@ register_flow(
     'convert',
     [
         'reshape_constant',
+        'resize_constant',
         'quant_constant_parameters',
         'quant_to_activation',
         'fuse_quant_with_constant',
@@ -51,6 +52,7 @@ register_flow(
         'merge_to_apply_alpha_div',
         'matmul_const_to_dense',
         'conv_to_conv_x_d',
+        'conv_to_depthwise_conv_x_d',
         'fuse_consecutive_batch_normalization',  # needs to be before infer_precision_types
         'merge_linear_activation',  # needs to be before infer_precision_types
         'fuse_batch_normalization',  # needs to be before infer_precision_types

--- a/hls4ml/model/optimizer/passes/batchnorm_opt.py
+++ b/hls4ml/model/optimizer/passes/batchnorm_opt.py
@@ -98,7 +98,7 @@ class ConstantBatchNormFusion(OptimizerPass):
 
         const_prec = const_node.get_output_variable().type.precision
 
-        new_val = const_node.value * node.weights['scale'].data_unquantized + node.weights['bias'].data_unquantized
+        new_val = const_node.get_attr('value') * node.weights['scale'].data_unquantized + node.weights['bias'].data_unquantized
 
         const_node.set_attr('value', new_val)
         const_node.set_attr('quantizer', node.get_attr('quantizer'))  # None if not defined

--- a/hls4ml/model/optimizer/passes/conv_to_convxd.py
+++ b/hls4ml/model/optimizer/passes/conv_to_convxd.py
@@ -29,12 +29,16 @@ class ConvToConvXD(OptimizerPass):
     """Convert Conv with constant to a Conv1D or Conv2D layer"""
 
     def match(self, node):
-        is_match = isinstance(node, Conv) and node.get_attr('group') == 1 and (
-            (len(node.inputs) == 2 and isinstance(node.get_input_node(node.inputs[1]), Constant))
-            or (
-                len(node.inputs) == 3
-                and isinstance(node.get_input_node(node.inputs[1]), Constant)
-                and isinstance(node.get_input_node(node.inputs[2]), Constant)
+        is_match = (
+            isinstance(node, Conv)
+            and node.get_attr('group') == 1
+            and (
+                (len(node.inputs) == 2 and isinstance(node.get_input_node(node.inputs[1]), Constant))
+                or (
+                    len(node.inputs) == 3
+                    and isinstance(node.get_input_node(node.inputs[1]), Constant)
+                    and isinstance(node.get_input_node(node.inputs[2]), Constant)
+                )
             )
         )
 

--- a/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
+++ b/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from hls4ml.model.layers import Constant, Conv, Conv1D, Conv2D
+from hls4ml.model.layers import Constant, Conv, DepthwiseConv1D, DepthwiseConv2D
 from hls4ml.model.optimizer import OptimizerPass
 
 # these are attributes to copy
@@ -25,11 +25,12 @@ _base_attributes = (
 )
 
 
-class ConvToConvXD(OptimizerPass):
-    """Convert Conv with constant to a Conv1D or Conv2D layer"""
+class ConvToDepthwiseConvXD(OptimizerPass):
+    """Convert Conv with constant to a DepthwiseConv1D or DepthwiseConv2D layer"""
 
     def match(self, node):
-        is_match = isinstance(node, Conv) and node.get_attr('group') == 1 and (
+        is_match = isinstance(node, Conv) and node.get_attr('group') == node.get_attr('n_chan') and 
+        (node.get_attr('group') != 1) and (
             (len(node.inputs) == 2 and isinstance(node.get_input_node(node.inputs[1]), Constant))
             or (
                 len(node.inputs) == 3
@@ -41,7 +42,7 @@ class ConvToConvXD(OptimizerPass):
         return is_match
 
     def transform(self, model, node):
-        """Convert Conv with constant to a Conv1D or Conv2D layer"""
+        """Convert Conv with constant to a DepthwiseConv1D or DepthwiseConv2D layer"""
 
         weight_node = node.get_input_node(node.inputs[1])
         weight_data = weight_node.attributes['value']
@@ -54,12 +55,12 @@ class ConvToConvXD(OptimizerPass):
 
         # The ConvxD nodes expect the weight data to be in a different format, not (M, k1.., C)
         if node.attributes['n_dim'] == 1:
-            newtype = Conv1D
-            attributes['weight_data'] = np.transpose(weight_data, (1, 2, 0))
+            newtype = DepthwiseConv1D
+            attributes['depthwise_data'] = np.transpose(weight_data, (1, 2, 0))
         else:
-            newtype = Conv2D
-            attributes['weight_data'] = np.transpose(weight_data, (1, 2, 3, 0))
-        attributes['weight_quantizer'] = weight_node.get_attr('quantizer')
+            newtype = DepthwiseConv2D
+            attributes['depthwise_data'] = np.transpose(weight_data, (1, 2, 3, 0))
+        attributes['depthwise_quantizer'] = weight_node.get_attr('quantizer')
 
         if bias_node:
             attributes['bias_data'] = bias_node.attributes['value']

--- a/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
+++ b/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
@@ -29,8 +29,11 @@ class ConvToDepthwiseConvXD(OptimizerPass):
     """Convert Conv with constant to a DepthwiseConv1D or DepthwiseConv2D layer"""
 
     def match(self, node):
-        is_match = isinstance(node, Conv) and node.get_attr('group') == node.get_attr('n_chan') and 
-        (node.get_attr('group') != 1) and (
+        is_match = (
+            isinstance(node, Conv) 
+            and node.get_attr('group') == node.get_attr('n_chan') 
+            and  node.get_attr('group') != 1
+            ) and (
             (len(node.inputs) == 2 and isinstance(node.get_input_node(node.inputs[1]), Constant))
             or (
                 len(node.inputs) == 3

--- a/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
+++ b/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
@@ -30,10 +30,8 @@ class ConvToDepthwiseConvXD(OptimizerPass):
 
     def match(self, node):
         is_match = (
-            isinstance(node, Conv) 
-            and node.get_attr('group') == node.get_attr('n_chan') 
-            and  node.get_attr('group') != 1
-            ) and (
+            isinstance(node, Conv) and node.get_attr('group') == node.get_attr('n_chan') and node.get_attr('group') != 1
+        ) and (
             (len(node.inputs) == 2 and isinstance(node.get_input_node(node.inputs[1]), Constant))
             or (
                 len(node.inputs) == 3

--- a/hls4ml/model/optimizer/passes/quant_opt.py
+++ b/hls4ml/model/optimizer/passes/quant_opt.py
@@ -356,6 +356,8 @@ def _calculate_precision_quantizer(bitwidth, integer, signed, narrow, rounding_m
     """
     A function to determine the precision and quantizer
     """
+    if isinstance(integer, np.ndarray) and np.all(integer == integer[0]):
+        integer = integer[0]
     if rounding_mode == 'ROUND':
         bn_round = 'AP_RND_CONV'
     elif rounding_mode == 'FLOOR':

--- a/hls4ml/model/optimizer/passes/resize_const.py
+++ b/hls4ml/model/optimizer/passes/resize_const.py
@@ -22,6 +22,9 @@ class ResizeConstant(OptimizerPass):
         """
         scales_node = node.get_input_node(node.inputs[-1])
         node.inputs[-1] = ''
+        scales_values = scales_node.get_attr('value')
+        node.set_attr('out_width', int(node.get_attr('in_width') * scales_values[1]))
+        node.set_attr('out_height', int(node.get_attr('in_height') * scales_values[2]))
         if not isinstance(scales_node, Constant):
             raise RuntimeError("Nonconstant shape inputs are not currently supported")
         model.remove_node(scales_node, rewire=False)

--- a/hls4ml/model/optimizer/passes/resize_const.py
+++ b/hls4ml/model/optimizer/passes/resize_const.py
@@ -20,10 +20,10 @@ class ResizeConstant(OptimizerPass):
         """
         Remove Constant from new shape input. Note, input shape node is already used on initialize
         """
-        shape_node = node.get_input_node(node.inputs[-1])
+        scales_node = node.get_input_node(node.inputs[-1])
         node.inputs[-1] = ''
-        if not isinstance(shape_node, Constant):
+        if not isinstance(scales_node, Constant):
             raise RuntimeError("Nonconstant shape inputs are not currently supported")
-        model.remove_node(shape_node, rewire=False)
+        model.remove_node(scales_node, rewire=False)
 
         return True

--- a/hls4ml/model/optimizer/passes/resize_const.py
+++ b/hls4ml/model/optimizer/passes/resize_const.py
@@ -1,0 +1,29 @@
+from hls4ml.model.layers import Constant, Resize
+from hls4ml.model.optimizer import OptimizerPass
+
+
+class ResizeConstant(OptimizerPass):
+    """
+    To compute the output shape of resize is necessary to access the scales, that
+    are stored as initilizer, later on converted as constant inputs.
+    ONNX has the output shape come as an input, not a parameter. This removes
+    the Constant input from new shape input, other than computing the output
+    shape for the resize node.
+    """
+
+    def match(self, node):
+        is_match = isinstance(node, Resize) and len(node.inputs) > 1 and node.get_input_node(node.inputs[-1])
+
+        return is_match
+
+    def transform(self, model, node):
+        """
+        Remove Constant from new shape input. Note, input shape node is already used on initialize
+        """
+        shape_node = node.get_input_node(node.inputs[-1])
+        node.inputs[-1] = ''
+        if not isinstance(shape_node, Constant):
+            raise RuntimeError("Nonconstant shape inputs are not currently supported")
+        model.remove_node(shape_node, rewire=False)
+
+        return True


### PR DESCRIPTION
## Description

With this PR hls4ml is able to properly convert QONNX models and generate HLS code for `Resize`, `DepthwiseConv` and `PointwiseConv`. The additions and modifications mainly consist in additions and/or modifications of optimisers and parser files. I suggest to review the conditions defined in `match()` methods of the optimisers in order to agree on their coherency. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue) [fixed one bug related to `PointwiseConv` optimiser]
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

I tested the code by converting an ONNX UNet model composed by `Depthwise+Pointwise Convs` and `Resize` nodes. The model is not public and I cannot share a test at the moment. I may can replicate part of the UNet network using random weights and use that model as a test for the aforemetioned node conversion and HLS generation.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
