### PR TITLE
Compilation for larger models enabled by increasing -fconstexpr-steps

### DIFF
--- a/hls4ml/templates/oneapi/CMakeLists.txt
+++ b/hls4ml/templates/oneapi/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 set(USER_FPGA_FLAGS -Wno-unused-label ${USER_FPGA_FLAGS})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
-set(USER_FLAGS -Wno-unused-label ${USER_FLAGS})
+set(USER_FLAGS -Wno-unused-label -fconstexpr-steps=134217728 ${USER_FLAGS})
 
 # Use cmake -DUSER_INCLUDE_PATHS=<paths> to set extra paths for general
 # compilation.


### PR DESCRIPTION
## Enable compilation of larger models


## Type of change

Compilation of oneAPI models fails with sufficiently large weight count. This can be avoided by adding `-fconstexpr-steps` flag.

```
In file included from /home/jupyter/hls4ml/model_out_oneapi/hls4ml_prj/src/firmware/myproject.cpp:8:
/home/jupyter/hls4ml/model_out_oneapi/hls4ml_prj/src/firmware/weights/w6.h:9:48: error: constexpr variable 'w6' must be initialized by a constant expression
/opt/intel/oneapi/2024.2/opt/oclfpga/include/sycl/ext/intel/ac_types/ac_fixed.hpp:521:5: note: constexpr evaluation hit maximum step limit; possible infinite loop?
```

- [x ] Bug fix (non-breaking change that fixes an issue)

## Tests

**Test Configuration**:


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
